### PR TITLE
Create Über-jar by adding manifold-all module

### DIFF
--- a/manifold-all/pom.xml
+++ b/manifold-all/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>systems.manifold</groupId>
+    <artifactId>manifold-parent</artifactId>
+    <version>0.1-alpha-1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>manifold-all</artifactId>
+
+  <name>Manifold :: Über-jar</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>systems.manifold</groupId>
+      <artifactId>manifold</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>systems.manifold</groupId>
+      <artifactId>manifold-collections</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>systems.manifold</groupId>
+      <artifactId>manifold-ext</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>systems.manifold</groupId>
+      <artifactId>manifold-io</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>systems.manifold</groupId>
+      <artifactId>manifold-js</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>systems.manifold</groupId>
+      <artifactId>manifold-json</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>systems.manifold</groupId>
+      <artifactId>manifold-text</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.1.0</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/manifold-collections-test/pom.xml
+++ b/manifold-collections-test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>systems.manifold</groupId>
     <artifactId>manifold-parent</artifactId>
-    <version>0.1-alpha-SNAPSHOT</version>
+    <version>0.1-alpha-1-SNAPSHOT</version>
   </parent>
 
   <artifactId>manifold-collections-test</artifactId>

--- a/manifold-collections-test/pom.xml
+++ b/manifold-collections-test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>systems.manifold</groupId>
     <artifactId>manifold-parent</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.1-alpha-SNAPSHOT</version>
   </parent>
 
   <artifactId>manifold-collections-test</artifactId>

--- a/manifold-collections/pom.xml
+++ b/manifold-collections/pom.xml
@@ -4,7 +4,7 @@
     <parent>
       <groupId>systems.manifold</groupId>
       <artifactId>manifold-parent</artifactId>
-      <version>0.1-alpha-SNAPSHOT</version>
+      <version>0.1-alpha-1-SNAPSHOT</version>
     </parent>
 
     <artifactId>manifold-collections</artifactId>

--- a/manifold-collections/pom.xml
+++ b/manifold-collections/pom.xml
@@ -4,7 +4,7 @@
     <parent>
       <groupId>systems.manifold</groupId>
       <artifactId>manifold-parent</artifactId>
-      <version>0.1-SNAPSHOT</version>
+      <version>0.1-alpha-SNAPSHOT</version>
     </parent>
 
     <artifactId>manifold-collections</artifactId>

--- a/manifold-docs/pom.xml
+++ b/manifold-docs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>systems.manifold</groupId>
         <artifactId>manifold-parent</artifactId>
-        <version>0.1-alpha-SNAPSHOT</version>
+        <version>0.1-alpha-1-SNAPSHOT</version>
     </parent>
 
     <artifactId>manifold-docs</artifactId>

--- a/manifold-docs/pom.xml
+++ b/manifold-docs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>systems.manifold</groupId>
         <artifactId>manifold-parent</artifactId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1-alpha-SNAPSHOT</version>
     </parent>
 
     <artifactId>manifold-docs</artifactId>

--- a/manifold-ext-test/pom.xml
+++ b/manifold-ext-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
       <groupId>systems.manifold</groupId>
       <artifactId>manifold-parent</artifactId>
-      <version>0.1-alpha-SNAPSHOT</version>
+      <version>0.1-alpha-1-SNAPSHOT</version>
     </parent>
 
     <artifactId>manifold-ext-test</artifactId>

--- a/manifold-ext-test/pom.xml
+++ b/manifold-ext-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
       <groupId>systems.manifold</groupId>
       <artifactId>manifold-parent</artifactId>
-      <version>0.1-SNAPSHOT</version>
+      <version>0.1-alpha-SNAPSHOT</version>
     </parent>
 
     <artifactId>manifold-ext-test</artifactId>

--- a/manifold-ext/pom.xml
+++ b/manifold-ext/pom.xml
@@ -5,7 +5,7 @@
     <parent>
       <groupId>systems.manifold</groupId>
       <artifactId>manifold-parent</artifactId>
-      <version>0.1-alpha-SNAPSHOT</version>
+      <version>0.1-alpha-1-SNAPSHOT</version>
     </parent>
 
     <artifactId>manifold-ext</artifactId>

--- a/manifold-ext/pom.xml
+++ b/manifold-ext/pom.xml
@@ -5,7 +5,7 @@
     <parent>
       <groupId>systems.manifold</groupId>
       <artifactId>manifold-parent</artifactId>
-      <version>0.1-SNAPSHOT</version>
+      <version>0.1-alpha-SNAPSHOT</version>
     </parent>
 
     <artifactId>manifold-ext</artifactId>

--- a/manifold-io-test/pom.xml
+++ b/manifold-io-test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>systems.manifold</groupId>
     <artifactId>manifold-parent</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.1-alpha-SNAPSHOT</version>
   </parent>
 
   <artifactId>manifold-io-test</artifactId>

--- a/manifold-io-test/pom.xml
+++ b/manifold-io-test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>systems.manifold</groupId>
     <artifactId>manifold-parent</artifactId>
-    <version>0.1-alpha-SNAPSHOT</version>
+    <version>0.1-alpha-1-SNAPSHOT</version>
   </parent>
 
   <artifactId>manifold-io-test</artifactId>

--- a/manifold-io/pom.xml
+++ b/manifold-io/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>systems.manifold</groupId>
     <artifactId>manifold-parent</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.1-alpha-SNAPSHOT</version>
   </parent>
 
   <artifactId>manifold-io</artifactId>

--- a/manifold-io/pom.xml
+++ b/manifold-io/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>systems.manifold</groupId>
     <artifactId>manifold-parent</artifactId>
-    <version>0.1-alpha-SNAPSHOT</version>
+    <version>0.1-alpha-1-SNAPSHOT</version>
   </parent>
 
   <artifactId>manifold-io</artifactId>

--- a/manifold-js-test/pom.xml
+++ b/manifold-js-test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>systems.manifold</groupId>
     <artifactId>manifold-parent</artifactId>
-    <version>0.1-alpha-SNAPSHOT</version>
+    <version>0.1-alpha-1-SNAPSHOT</version>
   </parent>
 
   <artifactId>manifold-js-test</artifactId>

--- a/manifold-js-test/pom.xml
+++ b/manifold-js-test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>systems.manifold</groupId>
     <artifactId>manifold-parent</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.1-alpha-SNAPSHOT</version>
   </parent>
 
   <artifactId>manifold-js-test</artifactId>

--- a/manifold-js/pom.xml
+++ b/manifold-js/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>systems.manifold</groupId>
     <artifactId>manifold-parent</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.1-alpha-SNAPSHOT</version>
   </parent>
 
   <artifactId>manifold-js</artifactId>

--- a/manifold-js/pom.xml
+++ b/manifold-js/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>systems.manifold</groupId>
     <artifactId>manifold-parent</artifactId>
-    <version>0.1-alpha-SNAPSHOT</version>
+    <version>0.1-alpha-1-SNAPSHOT</version>
   </parent>
 
   <artifactId>manifold-js</artifactId>

--- a/manifold-json-test/pom.xml
+++ b/manifold-json-test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>systems.manifold</groupId>
     <artifactId>manifold-parent</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.1-alpha-SNAPSHOT</version>
   </parent>
 
   <artifactId>manifold-json-test</artifactId>

--- a/manifold-json-test/pom.xml
+++ b/manifold-json-test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>systems.manifold</groupId>
     <artifactId>manifold-parent</artifactId>
-    <version>0.1-alpha-SNAPSHOT</version>
+    <version>0.1-alpha-1-SNAPSHOT</version>
   </parent>
 
   <artifactId>manifold-json-test</artifactId>

--- a/manifold-json/pom.xml
+++ b/manifold-json/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>systems.manifold</groupId>
     <artifactId>manifold-parent</artifactId>
-    <version>0.1-alpha-SNAPSHOT</version>
+    <version>0.1-alpha-1-SNAPSHOT</version>
   </parent>
 
   <artifactId>manifold-json</artifactId>

--- a/manifold-json/pom.xml
+++ b/manifold-json/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>systems.manifold</groupId>
     <artifactId>manifold-parent</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.1-alpha-SNAPSHOT</version>
   </parent>
 
   <artifactId>manifold-json</artifactId>

--- a/manifold-templates-test/pom.xml
+++ b/manifold-templates-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>systems.manifold</groupId>
         <artifactId>manifold-parent</artifactId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1-alpha-SNAPSHOT</version>
     </parent>
 
     <artifactId>manifold-templates-test</artifactId>

--- a/manifold-templates-test/pom.xml
+++ b/manifold-templates-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>systems.manifold</groupId>
         <artifactId>manifold-parent</artifactId>
-        <version>0.1-alpha-SNAPSHOT</version>
+        <version>0.1-alpha-1-SNAPSHOT</version>
     </parent>
 
     <artifactId>manifold-templates-test</artifactId>

--- a/manifold-templates/pom.xml
+++ b/manifold-templates/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>systems.manifold</groupId>
         <artifactId>manifold-parent</artifactId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1-alpha-SNAPSHOT</version>
     </parent>
     <artifactId>manifold-templates</artifactId>
     <name>Manifold :: Templates</name>

--- a/manifold-templates/pom.xml
+++ b/manifold-templates/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>systems.manifold</groupId>
         <artifactId>manifold-parent</artifactId>
-        <version>0.1-alpha-SNAPSHOT</version>
+        <version>0.1-alpha-1-SNAPSHOT</version>
     </parent>
     <artifactId>manifold-templates</artifactId>
     <name>Manifold :: Templates</name>

--- a/manifold-test/pom.xml
+++ b/manifold-test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>systems.manifold</groupId>
     <artifactId>manifold-parent</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.1-alpha-SNAPSHOT</version>
   </parent>
 
   <artifactId>manifold-test</artifactId>

--- a/manifold-test/pom.xml
+++ b/manifold-test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>systems.manifold</groupId>
     <artifactId>manifold-parent</artifactId>
-    <version>0.1-alpha-SNAPSHOT</version>
+    <version>0.1-alpha-1-SNAPSHOT</version>
   </parent>
 
   <artifactId>manifold-test</artifactId>

--- a/manifold-text-test/pom.xml
+++ b/manifold-text-test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>systems.manifold</groupId>
     <artifactId>manifold-parent</artifactId>
-    <version>0.1-alpha-SNAPSHOT</version>
+    <version>0.1-alpha-1-SNAPSHOT</version>
   </parent>
 
   <artifactId>manifold-text-test</artifactId>

--- a/manifold-text-test/pom.xml
+++ b/manifold-text-test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>systems.manifold</groupId>
     <artifactId>manifold-parent</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.1-alpha-SNAPSHOT</version>
   </parent>
 
   <artifactId>manifold-text-test</artifactId>

--- a/manifold-text/pom.xml
+++ b/manifold-text/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>systems.manifold</groupId>
     <artifactId>manifold-parent</artifactId>
-    <version>0.1-alpha-SNAPSHOT</version>
+    <version>0.1-alpha-1-SNAPSHOT</version>
   </parent>
 
   <artifactId>manifold-text</artifactId>

--- a/manifold-text/pom.xml
+++ b/manifold-text/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>systems.manifold</groupId>
     <artifactId>manifold-parent</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.1-alpha-SNAPSHOT</version>
   </parent>
 
   <artifactId>manifold-text</artifactId>

--- a/manifold/pom.xml
+++ b/manifold/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>systems.manifold</groupId>
     <artifactId>manifold-parent</artifactId>
-    <version>0.1-alpha-SNAPSHOT</version>
+    <version>0.1-alpha-1-SNAPSHOT</version>
   </parent>
 
   <artifactId>manifold</artifactId>

--- a/manifold/pom.xml
+++ b/manifold/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>systems.manifold</groupId>
     <artifactId>manifold-parent</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.1-alpha-SNAPSHOT</version>
   </parent>
 
   <artifactId>manifold</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>systems.manifold</groupId>
   <artifactId>manifold-parent</artifactId>
   <packaging>pom</packaging>
-  <version>0.1-SNAPSHOT</version>
+  <version>0.1-alpha-SNAPSHOT</version>
 
   <name>Manifold :: Parent</name>
   <description>Manifold is a unique framework to dynamically and seamlessly extend Java's type system.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
     <module>manifold-templates</module>
     <module>manifold-templates-test</module>
     <module>manifold-docs</module>
+    <module>manifold-all</module>
   </modules>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>systems.manifold</groupId>
   <artifactId>manifold-parent</artifactId>
   <packaging>pom</packaging>
-  <version>0.1-alpha-SNAPSHOT</version>
+  <version>0.1-alpha-1-SNAPSHOT</version>
 
   <name>Manifold :: Parent</name>
   <description>Manifold is a unique framework to dynamically and seamlessly extend Java's type system.</description>


### PR DESCRIPTION
 - Aggregates ServiceLoader implementations of m.a.t.ITypeManifold

I uploaded a preview of the über-jar at: https://oss.jfrog.org/artifactory/oss-snapshot-local/systems/manifold/manifold-all/0.1-alpha-1-SNAPSHOT/manifold-all-0.1-alpha-1-20171011.155318-1.jar

Note that collections is missing from the services definition. Is that intentional?