### PR TITLE
fix broken gif in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ to your overall experience with your development environment.  For instance,
 code-completion conveniently presents all the extension methods available on an
 extended class:
 
-<p><img src="https://i.imgur.com/ttVAgHK.gifv" alt="echo method" width="100%" height="100%"/></p>
+<p><img src="https://i.imgur.com/ttVAgHK.gif" alt="echo method" width="100%" height="100%"/></p>
 
 
 There's a lot more to the extension manifold including [structural interfaces](#structural-interfaces), which are


### PR DESCRIPTION
Hello,

I noticed the extension method gif in the README doesn't display properly in Firefox on Linux. This manifests on the [GitHub page.](https://github.com/manifold-systems/manifold) (see screenshot) The fix is rather trivial, [hopefully you can see that it displays on my branch.](https://github.com/lourkeur/manifold/blob/gif/README.md#the-extension-manifold)

By the way, the project looks amazing for what I can see. I'll look deeper into it than the web console on the GitHub page soon :wink: 

 ![screenshot](https://user-images.githubusercontent.com/15657735/35484228-7c65d832-044d-11e8-8ffa-985e0eac77b9.png)