### PR TITLE
Fix for unwanted tools.jar dependency in manifold-all pom.xml

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -347,6 +347,55 @@ to use all basic manifold features, this is the recommended setup.
     </profile>
   </profiles>
 ```
+***Surefire***
+
+For Java 8, executing tests of classes leveraging Manifold will also require `tools.jar` at test execution time.
+
+Here is a simple project layout demonstrating use of the `manifold-all` dependency and including `tools.jar` with Surefire:
+
+```xml
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.7.0</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+          <compilerArgs>
+            <arg>-Xplugin:Manifold</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.20.1</version>
+        <configuration>
+          <additionalClasspathElements>
+            <additionalClasspathElement>${java.home}/../lib/tools.jar</additionalClasspathElement>
+          </additionalClasspathElements>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>systems.manifold</groupId>
+      <artifactId>manifold-all</artifactId>
+      <version>RELEASE</version> <!-- there were known issues with manifold-all 0.9-alpha and earlier -->
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+    </dependency>
+  </dependencies>
+```
+
+Note the above snippet should work with `manifold-all` release `0.10-alpha` and beyond.
 
 **Archetype**
 

--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
       <id>internal.tools-jar</id>
       <activation>
         <file>
-          <exists>${java.home}/../lib/tools.jar</exists>
+          <missing>src/main/java/systems/manifold/Dummy.java</missing>
         </file>
       </activation>
       <dependencies>


### PR DESCRIPTION
As discovered on this [SO thread](https://stackoverflow.com/questions/48715546/maven-how-to-specify-javac-plugin-argument-with-maven-compiler-plugin), our `<system>` scope dependency on `tools.jar` needed to compile the core Manifold libs was leaking in to `manifold-all`'s `dependency-reduced-pom.xml` file, part of the `maven-shade-plugin` execution. This is a little embarrassing since the `java.home` sysprop of the build machine was being exposed and exported in our release builds. 

This one-line fix prevents the `internal.tools-jar` profile from being applied to the `manifold-all` module. In addition, I'm including docs to explain how to use future releases of `manifold-all` with the `maven-surefire-plugin`. Finally, I will update the archetype to reflect these recommended surefire settings.