### PR TITLE
Only activate `internal.tools-jar` profile for Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,26 @@
           <updateWorkingCopyVersions>false</updateWorkingCopyVersions>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.0.0-M1</version>
+        <executions>
+          <execution>
+            <id>enforce-versions</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>[3.2.2,)</version> <!-- https://stackoverflow.com/a/4629269/4750893 -->
+                </requireMavenVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
 
     <pluginManagement>
@@ -166,6 +186,7 @@
     <profile>
       <id>internal.tools-jar</id>
       <activation>
+        <jdk>1.8</jdk>
         <file>
           <missing>src/main/java/systems/manifold/Dummy.java</missing>
         </file>


### PR DESCRIPTION
 - Unfortnately, a bug in Maven 3.2.1 and earlier does not allow a profile to have multiple activations
 - Adding maven-enforcer-plugin to build to guarantee that the version of maven used is >= 3.2.2
 - Build will fail with this message if using 3.2.1:
```
[WARNING] Rule 0: org.apache.maven.plugins.enforcer.RequireMavenVersion failed with message:
Detected Maven Version: 3.2.1 is not in the allowed range [3.2.2,).
```