### PR TITLE
manifold-jdbc

### DIFF
--- a/docs/articles/manifold_series_2.md
+++ b/docs/articles/manifold_series_2.md
@@ -245,6 +245,12 @@ to your project separately depending on your needs.
     - java.io.Reader
     - java.io.Writer
 
+*   **JDBC**
+
+    Defined in module `manifold-jdbc` this library extends:
+    - java.sql.ResultSet
+    - java.sql.CallableStatement
+
 *   **Web/Json**
  
     Defined in module `manifold-json` this library extends:

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -349,7 +349,8 @@ I/O extensions
 Text extensions
 * [manifold-templates](https://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=systems.manifold&a=manifold-templates&v=RELEASE):
 Integrated template support
-
+* [manifold-jdbc](https://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=systems.manifold&a=manifold-jdbc&v=RELEASE):
+JDBC extensions
 
 ## Maven
 To setup a Maven project with Manifold you must:
@@ -456,6 +457,13 @@ recommended setup.
     <artifactId>manifold-text</artifactId>
     <version>RELEASE</version>
   </dependency>    
+  
+  <!--JDBC extensions-->
+  <dependency>
+    <groupId>systems.manifold</groupId>
+    <artifactId>manifold-jdbc</artifactId>
+    <version>RELEASE</version>
+  </dependency>
 ```
 
 **Configure the maven-compiler-plugin**
@@ -2557,6 +2565,12 @@ to your project separately depending on its needs.
     - java.io.OutputStream
     - java.io.Reader
     - java.io.Writer
+
+*   **JDBC**
+
+    Defined in module `manifold-jdbc` this library extends:
+    - java.sql.ResultSet
+    - java.sql.CallableStatement
 
 *   **Web/JSON/YAML**
  

--- a/manifold-all/pom.xml
+++ b/manifold-all/pom.xml
@@ -49,6 +49,11 @@
     </dependency>
     <dependency>
       <groupId>systems.manifold</groupId>
+      <artifactId>manifold-jdbc</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>systems.manifold</groupId>
       <artifactId>manifold-js</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -64,17 +69,17 @@
     </dependency>
     <dependency>
       <groupId>systems.manifold</groupId>
-      <artifactId>manifold-yaml</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>systems.manifold</groupId>
       <artifactId>manifold-templates</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>systems.manifold</groupId>
       <artifactId>manifold-text</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>systems.manifold</groupId>
+      <artifactId>manifold-yaml</artifactId>
       <version>${project.version}</version>
     </dependency>
   </dependencies>

--- a/manifold-deps-parent/manifold-jdbc-test/pom.xml
+++ b/manifold-deps-parent/manifold-jdbc-test/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>systems.manifold</groupId>
+    <artifactId>manifold-deps-parent</artifactId>
+    <version>0.69-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>manifold-jdbc-test</artifactId>
+
+  <name>Manifold :: JdbcTest</name>
+  
+  <dependencies>
+    <dependency>
+      <groupId>systems.manifold</groupId>
+      <artifactId>manifold-jdbc</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>systems.manifold</groupId>
+      <artifactId>manifold-ext-test</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/manifold-deps-parent/manifold-jdbc-test/src/test/java/manifold/jdbc/extensions/java/sql/CallableStatement/ManCallableStatementExtTest.java
+++ b/manifold-deps-parent/manifold-jdbc-test/src/test/java/manifold/jdbc/extensions/java/sql/CallableStatement/ManCallableStatementExtTest.java
@@ -1,0 +1,105 @@
+package manifold.jdbc.extensions.java.sql.CallableStatement;
+
+import manifold.test.api.ExtensionManifoldTest;
+
+import java.sql.CallableStatement;
+import java.sql.SQLException;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ManCallableStatementExtTest extends ExtensionManifoldTest
+{
+
+  private static final int COLUMN_INDEX = 1;
+  private static final String COLUMN_LABEL = "id";
+
+  @Override
+  public void testCoverage()
+  {
+    testCoverage( ManCallableStatementExt.class );
+  }
+
+  public void testGetIntOrNull() throws Exception
+  {
+    assertThat( callByIndex( CallableStatement::getInt, 1, false, ManCallableStatementExt::getIntOrNull ), equalTo( 1 ) );
+    assertThat( callByIndex( CallableStatement::getInt, 0, false, ManCallableStatementExt::getIntOrNull ), equalTo( 0 ) );
+    assertThat( callByIndex( CallableStatement::getInt, 0, true, ManCallableStatementExt::getIntOrNull ), nullValue() );
+
+    assertThat( callByLabel( CallableStatement::getInt, 1, false, ManCallableStatementExt::getIntOrNull ), equalTo( 1 ) );
+    assertThat( callByLabel( CallableStatement::getInt, 0, false, ManCallableStatementExt::getIntOrNull ), equalTo( 0 ) );
+    assertThat( callByLabel( CallableStatement::getInt, 0, true, ManCallableStatementExt::getIntOrNull ), nullValue() );
+  }
+
+  public void testGetLongOrNull() throws Exception
+  {
+    assertThat( callByIndex( CallableStatement::getLong, 1L, false, ManCallableStatementExt::getLongOrNull ), equalTo( 1L ) );
+    assertThat( callByIndex( CallableStatement::getLong, 0L, false, ManCallableStatementExt::getLongOrNull ), equalTo( 0L ) );
+    assertThat( callByIndex( CallableStatement::getLong, 0L, true, ManCallableStatementExt::getLongOrNull ), nullValue() );
+
+    assertThat( callByLabel( CallableStatement::getLong, 1L, false, ManCallableStatementExt::getLongOrNull ), equalTo( 1L ) );
+    assertThat( callByLabel( CallableStatement::getLong, 0L, false, ManCallableStatementExt::getLongOrNull ), equalTo( 0L ) );
+    assertThat( callByLabel( CallableStatement::getLong, 0L, true, ManCallableStatementExt::getLongOrNull ), nullValue() );
+  }
+
+  public void testGetDoubleOrNull() throws Exception
+  {
+    assertThat( callByIndex( CallableStatement::getDouble, 1d, false, ManCallableStatementExt::getDoubleOrNull ), equalTo( 1d ) );
+    assertThat( callByIndex( CallableStatement::getDouble, 0d, false, ManCallableStatementExt::getDoubleOrNull ), equalTo( 0d ) );
+    assertThat( callByIndex( CallableStatement::getDouble, 0d, true, ManCallableStatementExt::getDoubleOrNull ), nullValue() );
+
+    assertThat( callByLabel( CallableStatement::getDouble, 1d, false, ManCallableStatementExt::getDoubleOrNull ), equalTo( 1d ) );
+    assertThat( callByLabel( CallableStatement::getDouble, 0d, false, ManCallableStatementExt::getDoubleOrNull ), equalTo( 0d ) );
+    assertThat( callByLabel( CallableStatement::getDouble, 0d, true, ManCallableStatementExt::getDoubleOrNull ), nullValue() );
+  }
+
+  private static <T> T callByIndex( IndexColumnSupplier<T> rsMapper, T returned, boolean wasNull,
+                                    IndexColumnSupplier<T> extMapper ) throws Exception
+  {
+    CallableStatement rs = mock( CallableStatement.class );
+    when( rsMapper.get( rs, COLUMN_INDEX ) )
+        .thenReturn( returned );
+    when( rs.wasNull() )
+        .thenReturn( wasNull );
+
+    T value = extMapper.get( rs, COLUMN_INDEX );
+
+    rsMapper.get( verify( rs ), COLUMN_INDEX );
+    verify( rs ).wasNull();
+
+    return value;
+  }
+
+  private static <T> T callByLabel( LabelColumnSupplier<T> rsMapper, T returned, boolean wasNull,
+                                    LabelColumnSupplier<T> extMapper ) throws Exception
+  {
+    CallableStatement rs = mock( CallableStatement.class );
+    when( rsMapper.get( rs, COLUMN_LABEL ) )
+        .thenReturn( returned );
+    when( rs.wasNull() )
+        .thenReturn( wasNull );
+
+    T value = extMapper.get( rs, COLUMN_LABEL );
+
+    rsMapper.get( verify( rs ), COLUMN_LABEL );
+    verify( rs ).wasNull();
+
+    return value;
+  }
+
+  @FunctionalInterface
+  private interface IndexColumnSupplier<T>
+  {
+    T get( CallableStatement rs, int index ) throws SQLException;
+  }
+
+  @FunctionalInterface
+  private interface LabelColumnSupplier<T>
+  {
+    T get( CallableStatement rs, String label ) throws SQLException;
+  }
+}

--- a/manifold-deps-parent/manifold-jdbc-test/src/test/java/manifold/jdbc/extensions/java/sql/ResultSet/ManResultSetExtTest.java
+++ b/manifold-deps-parent/manifold-jdbc-test/src/test/java/manifold/jdbc/extensions/java/sql/ResultSet/ManResultSetExtTest.java
@@ -1,0 +1,105 @@
+package manifold.jdbc.extensions.java.sql.ResultSet;
+
+import manifold.test.api.ExtensionManifoldTest;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ManResultSetExtTest extends ExtensionManifoldTest
+{
+
+  private static final int COLUMN_INDEX = 1;
+  private static final String COLUMN_LABEL = "id";
+
+  @Override
+  public void testCoverage()
+  {
+    testCoverage( ManResultSetExt.class );
+  }
+
+  public void testGetIntOrNull() throws Exception
+  {
+    assertThat( callByIndex( ResultSet::getInt, 1, false, ManResultSetExt::getIntOrNull ), equalTo( 1 ) );
+    assertThat( callByIndex( ResultSet::getInt, 0, false, ManResultSetExt::getIntOrNull ), equalTo( 0 ) );
+    assertThat( callByIndex( ResultSet::getInt, 0, true, ManResultSetExt::getIntOrNull ), nullValue() );
+
+    assertThat( callByLabel( ResultSet::getInt, 1, false, ManResultSetExt::getIntOrNull ), equalTo( 1 ) );
+    assertThat( callByLabel( ResultSet::getInt, 0, false, ManResultSetExt::getIntOrNull ), equalTo( 0 ) );
+    assertThat( callByLabel( ResultSet::getInt, 0, true, ManResultSetExt::getIntOrNull ), nullValue() );
+  }
+
+  public void testGetLongOrNull() throws Exception
+  {
+    assertThat( callByIndex( ResultSet::getLong, 1L, false, ManResultSetExt::getLongOrNull ), equalTo( 1L ) );
+    assertThat( callByIndex( ResultSet::getLong, 0L, false, ManResultSetExt::getLongOrNull ), equalTo( 0L ) );
+    assertThat( callByIndex( ResultSet::getLong, 0L, true, ManResultSetExt::getLongOrNull ), nullValue() );
+
+    assertThat( callByLabel( ResultSet::getLong, 1L, false, ManResultSetExt::getLongOrNull ), equalTo( 1L ) );
+    assertThat( callByLabel( ResultSet::getLong, 0L, false, ManResultSetExt::getLongOrNull ), equalTo( 0L ) );
+    assertThat( callByLabel( ResultSet::getLong, 0L, true, ManResultSetExt::getLongOrNull ), nullValue() );
+  }
+
+  public void testGetDoubleOrNull() throws Exception
+  {
+    assertThat( callByIndex( ResultSet::getDouble, 1d, false, ManResultSetExt::getDoubleOrNull ), equalTo( 1d ) );
+    assertThat( callByIndex( ResultSet::getDouble, 0d, false, ManResultSetExt::getDoubleOrNull ), equalTo( 0d ) );
+    assertThat( callByIndex( ResultSet::getDouble, 0d, true, ManResultSetExt::getDoubleOrNull ), nullValue() );
+
+    assertThat( callByLabel( ResultSet::getDouble, 1d, false, ManResultSetExt::getDoubleOrNull ), equalTo( 1d ) );
+    assertThat( callByLabel( ResultSet::getDouble, 0d, false, ManResultSetExt::getDoubleOrNull ), equalTo( 0d ) );
+    assertThat( callByLabel( ResultSet::getDouble, 0d, true, ManResultSetExt::getDoubleOrNull ), nullValue() );
+  }
+
+  private static <T> T callByIndex( IndexColumnSupplier<T> rsMapper, T returned, boolean wasNull,
+                                    IndexColumnSupplier<T> extMapper ) throws Exception
+  {
+    ResultSet rs = mock( ResultSet.class );
+    when( rsMapper.get( rs, COLUMN_INDEX ) )
+        .thenReturn( returned );
+    when( rs.wasNull() )
+        .thenReturn( wasNull );
+
+    T value = extMapper.get( rs, COLUMN_INDEX );
+
+    rsMapper.get( verify( rs ), COLUMN_INDEX );
+    verify( rs ).wasNull();
+
+    return value;
+  }
+
+  private static <T> T callByLabel( LabelColumnSupplier<T> rsMapper, T returned, boolean wasNull,
+                                    LabelColumnSupplier<T> extMapper ) throws Exception
+  {
+    ResultSet rs = mock( ResultSet.class );
+    when( rsMapper.get( rs, COLUMN_LABEL ) )
+        .thenReturn( returned );
+    when( rs.wasNull() )
+        .thenReturn( wasNull );
+
+    T value = extMapper.get( rs, COLUMN_LABEL );
+
+    rsMapper.get( verify( rs ), COLUMN_LABEL );
+    verify( rs ).wasNull();
+
+    return value;
+  }
+
+  @FunctionalInterface
+  private interface IndexColumnSupplier<T>
+  {
+    T get( ResultSet rs, int index ) throws SQLException;
+  }
+
+  @FunctionalInterface
+  private interface LabelColumnSupplier<T>
+  {
+    T get( ResultSet rs, String label ) throws SQLException;
+  }
+}

--- a/manifold-deps-parent/manifold-jdbc/pom.xml
+++ b/manifold-deps-parent/manifold-jdbc/pom.xml
@@ -8,21 +8,22 @@
     <version>0.69-SNAPSHOT</version>
   </parent>
 
-  <artifactId>manifold-graphql</artifactId>
+  <artifactId>manifold-jdbc</artifactId>
 
-  <name>Manifold :: GraphQL</name>
+  <name>Manifold :: JDBC</name>
 
   <dependencies>
     <dependency>
       <groupId>systems.manifold</groupId>
-      <artifactId>manifold-json</artifactId>
+      <artifactId>manifold</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.graphql-java</groupId>
-      <artifactId>graphql-java</artifactId>
-      <version>12.0</version>
+      <groupId>systems.manifold</groupId>
+      <artifactId>manifold-ext</artifactId>
+      <version>${project.version}</version>
     </dependency>
+
     <dependency>
       <groupId>org.jetbrains</groupId>
       <artifactId>annotations</artifactId>
@@ -45,6 +46,5 @@
       </plugin>
     </plugins>
   </build>
-
 
 </project>

--- a/manifold-deps-parent/manifold-jdbc/src/main/java/manifold/jdbc/extensions/java/sql/CallableStatement/ManCallableStatementExt.java
+++ b/manifold-deps-parent/manifold-jdbc/src/main/java/manifold/jdbc/extensions/java/sql/CallableStatement/ManCallableStatementExt.java
@@ -1,0 +1,79 @@
+package manifold.jdbc.extensions.java.sql.CallableStatement;
+
+import manifold.ext.api.Extension;
+import manifold.ext.api.This;
+import org.jetbrains.annotations.Nullable;
+
+import java.sql.CallableStatement;
+import java.sql.SQLException;
+
+@Extension
+public class ManCallableStatementExt
+{
+
+  @Nullable
+  public static Integer getIntOrNull( @This CallableStatement thiz, int columnIndex ) throws SQLException
+  {
+    int value = thiz.getInt( columnIndex );
+    if( thiz.wasNull() )
+    {
+      return null;
+    }
+    return value;
+  }
+
+  @Nullable
+  public static Integer getIntOrNull( @This CallableStatement thiz, String columnLabel ) throws SQLException
+  {
+    int value = thiz.getInt( columnLabel );
+    if( thiz.wasNull() )
+    {
+      return null;
+    }
+    return value;
+  }
+
+  @Nullable
+  public static Long getLongOrNull( @This CallableStatement thiz, int columnIndex ) throws SQLException
+  {
+    long value = thiz.getLong( columnIndex );
+    if( thiz.wasNull() )
+    {
+      return null;
+    }
+    return value;
+  }
+
+  @Nullable
+  public static Long getLongOrNull( @This CallableStatement thiz, String columnLabel ) throws SQLException
+  {
+    long value = thiz.getLong( columnLabel );
+    if( thiz.wasNull() )
+    {
+      return null;
+    }
+    return value;
+  }
+
+  @Nullable
+  public static Double getDoubleOrNull( @This CallableStatement thiz, int columnIndex ) throws SQLException
+  {
+    double value = thiz.getDouble( columnIndex );
+    if( thiz.wasNull() )
+    {
+      return null;
+    }
+    return value;
+  }
+
+  @Nullable
+  public static Double getDoubleOrNull( @This CallableStatement thiz, String columnLabel ) throws SQLException
+  {
+    double value = thiz.getDouble( columnLabel );
+    if( thiz.wasNull() )
+    {
+      return null;
+    }
+    return value;
+  }
+}

--- a/manifold-deps-parent/manifold-jdbc/src/main/java/manifold/jdbc/extensions/java/sql/ResultSet/ManResultSetExt.java
+++ b/manifold-deps-parent/manifold-jdbc/src/main/java/manifold/jdbc/extensions/java/sql/ResultSet/ManResultSetExt.java
@@ -1,0 +1,79 @@
+package manifold.jdbc.extensions.java.sql.ResultSet;
+
+import manifold.ext.api.Extension;
+import manifold.ext.api.This;
+import org.jetbrains.annotations.Nullable;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+@Extension
+public class ManResultSetExt
+{
+
+  @Nullable
+  public static Integer getIntOrNull( @This ResultSet thiz, int columnIndex ) throws SQLException
+  {
+    int value = thiz.getInt( columnIndex );
+    if( thiz.wasNull() )
+    {
+      return null;
+    }
+    return value;
+  }
+
+  @Nullable
+  public static Integer getIntOrNull( @This ResultSet thiz, String columnLabel ) throws SQLException
+  {
+    int value = thiz.getInt( columnLabel );
+    if( thiz.wasNull() )
+    {
+      return null;
+    }
+    return value;
+  }
+
+  @Nullable
+  public static Long getLongOrNull( @This ResultSet thiz, int columnIndex ) throws SQLException
+  {
+    long value = thiz.getLong( columnIndex );
+    if( thiz.wasNull() )
+    {
+      return null;
+    }
+    return value;
+  }
+
+  @Nullable
+  public static Long getLongOrNull( @This ResultSet thiz, String columnLabel ) throws SQLException
+  {
+    long value = thiz.getLong( columnLabel );
+    if( thiz.wasNull() )
+    {
+      return null;
+    }
+    return value;
+  }
+
+  @Nullable
+  public static Double getDoubleOrNull( @This ResultSet thiz, int columnIndex ) throws SQLException
+  {
+    double value = thiz.getDouble( columnIndex );
+    if( thiz.wasNull() )
+    {
+      return null;
+    }
+    return value;
+  }
+
+  @Nullable
+  public static Double getDoubleOrNull( @This ResultSet thiz, String columnLabel ) throws SQLException
+  {
+    double value = thiz.getDouble( columnLabel );
+    if( thiz.wasNull() )
+    {
+      return null;
+    }
+    return value;
+  }
+}

--- a/manifold-deps-parent/pom.xml
+++ b/manifold-deps-parent/pom.xml
@@ -33,6 +33,8 @@
     <module>manifold-io-test</module>
     <module>manifold-image</module>
     <module>manifold-image-test</module>
+    <module>manifold-jdbc</module>
+    <module>manifold-jdbc-test</module>
     <module>manifold-js</module>
     <module>manifold-js-test</module>
     <module>manifold-json</module>

--- a/pom.xml
+++ b/pom.xml
@@ -240,9 +240,21 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.jetbrains</groupId>
+        <artifactId>annotations</artifactId>
+        <version>16.0.2</version>
+      </dependency>
+
+      <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>4.12</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>2.27.0</version>
         <scope>test</scope>
       </dependency>
     </dependencies>


### PR DESCRIPTION
This PR suggests PoC manifold-jdbc module with extensions of interfaces ResultSet and CallableStatement.
Originally I used these methods as static imports in my enterprise applications, when I suddenly realized, that it's a pity that java does not support extension methods. Later I used these methods as extensions in my kotlin code.

Some implementation notes:
* intellij annotations usage policy is not clear - I see both no `Nullable` annotations in `ManifoldCollectionExt` and `Nullable` annotations in `graphql` module
* ResultSet can be simulated in H2/hsqldb driver, but these in-memory databases both do not support callable statements, so I decided to use mockito. Tests look a bit weird, but it's most clear and non-verbose implementation that I could make
* 100% line/branch test coverage (unit tests)

`manifold-sample-project` usage example (requires `com.h2database:h2` dependency):

    private static void useResultSet( )
    {
      out.println( "\n\n###Convenient ResultSet get nullable column values ###\n" );
      try (Connection conn = DriverManager.getConnection( "jdbc:h2:mem:manifold" )) {
        try ( Statement st = conn.createStatement() ) {
          try ( ResultSet rs = st.executeQuery( "SELECT null" )) {
            rs.next();
            Integer value = rs.getIntOrNull( 1 );
            out.println( "Got nullable column with value [" + value + "]");
          }
          try ( ResultSet rs = st.executeQuery( "SELECT 1" )) {
            rs.next();
            Integer value = rs.getIntOrNull( 1 );
            out.println( "Got nullable column with value [" + value + "]");
          }
        }
      }
    }
