### PR TITLE
Executor helper methods

### DIFF
--- a/manifold-deps-parent/manifold-graphql/src/main/java/manifold/graphql/request/Executor.java
+++ b/manifold-deps-parent/manifold-graphql/src/main/java/manifold/graphql/request/Executor.java
@@ -16,8 +16,9 @@
 
 package manifold.graphql.request;
 
-import javax.script.Bindings;
 import manifold.api.json.Requester;
+
+import javax.script.Bindings;
 
 /**
  * Based on:
@@ -123,6 +124,11 @@ public class Executor<T>
   public T post( Requester.Format format )
   {
     return (T)((Bindings)_requester.postOne( "", _reqArgs.getBindings(), format )).get( "data" );
+  }
+
+  public Bindings postBindings( Requester.Format format )
+  {
+    return ((Bindings)_requester.postOne( "", _reqArgs.getBindings(), format ));
   }
 
   /**


### PR DESCRIPTION
Added method in Executor to get whole graphql response. Today it's only possible to get the data part of the graphql response if you use the Executor as a graphql client. Now it will be possible to get the whole response (data and error),