### PR TITLE
Use getClassLoadingLock() when loading ManJavacParser

### DIFF
--- a/manifold-core-parent/manifold/src/main/java/manifold/internal/javac/JavacPlugin.java
+++ b/manifold-core-parent/manifold/src/main/java/manifold/internal/javac/JavacPlugin.java
@@ -1260,9 +1260,11 @@ public class JavacPlugin implements Plugin, TaskListener
    */
   private static void loadJavacParserClass()
   {
-    synchronized( JavacPlugin.class )
+    ClassLoader classLoader = JavacParser.class.getClassLoader();
+    synchronized(
+      ReflectUtil.method( classLoader, "getClassLoadingLock", String.class )
+        .invoke( "com.sun.tools.javac.parser.ManJavacParser" ) )
     {
-      ClassLoader classLoader = JavacParser.class.getClassLoader();
       if( null == ReflectUtil.method( classLoader, "findLoadedClass", String.class )
         .invoke( "com.sun.tools.javac.parser.ManJavacParser" ) )
       {


### PR DESCRIPTION
`JavacPlugin.loadJavacParserClass()` synchronises on `JavacPlugin.class` before adding `ManJavacParser` to the classloader. However, as mentioned in [#173](https://github.com/manifold-systems/manifold/issues/173#issuecomment-638588645), this can still lead to "attempted duplicate class definition" errors in parallel SBT builds, as distinct copies of `JavacPlugin.class` may be contending for the same classloader.

This can be avoided by synchronising on the result of `ClassLoader.getClassLoadingLock("com.sun.tools.javac.parser.ManJavacParser")` instead.