### PR TITLE
Add feature of issue #261

### DIFF
--- a/manifold-deps-parent/manifold-props-rt/src/main/java/manifold/ext/props/rt/api/PublicDefault.java
+++ b/manifold-deps-parent/manifold-props-rt/src/main/java/manifold/ext/props/rt/api/PublicDefault.java
@@ -1,0 +1,12 @@
+package manifold.ext.props.rt.api;
+
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.SOURCE)
+@Target({ElementType.TYPE})
+public @interface PublicDefault {
+}

--- a/manifold-deps-parent/manifold-props-test/src/test/java/manifold/ext/props/PublicDefaultTest.java
+++ b/manifold-deps-parent/manifold-props-test/src/test/java/manifold/ext/props/PublicDefaultTest.java
@@ -1,0 +1,30 @@
+package manifold.ext.props;
+
+import junit.framework.TestCase;
+import manifold.ext.props.rt.api.PublicDefault;
+import manifold.ext.props.stuff.PublicDefaultClass;
+import manifold.ext.props.stuff.PublicDefaultClass.defaultClass;
+
+public class PublicDefaultTest  extends TestCase {
+    public void testPublicDefaultVarAccess()
+    {
+        PublicDefaultClass defaultClass = new PublicDefaultClass(10,0,0,0);
+        assertEquals(defaultClass.PublicVar, 0);
+        assertEquals(defaultClass.defaultPublicVar, 10);
+    }
+
+    public void testPublicDefaultFunctionAccess()
+    {
+        PublicDefaultClass defaultClass = new PublicDefaultClass(10,0,0,0);
+        assertEquals(defaultClass.defaultAddFunction(2,3), 5);
+    }
+
+    public void testPublicDefaultClassAccess()
+    {
+        PublicDefaultClass.defaultClass defaultClass = new PublicDefaultClass.defaultClass();
+        assertEquals(defaultClass.reachablePublicVar, 0);
+        //static is auto added
+        PublicDefaultClass.publicClass publicClass = new PublicDefaultClass.publicClass();
+
+    }
+}

--- a/manifold-deps-parent/manifold-props-test/src/test/java/manifold/ext/props/stuff/PublicDefaultClass.java
+++ b/manifold-deps-parent/manifold-props-test/src/test/java/manifold/ext/props/stuff/PublicDefaultClass.java
@@ -1,0 +1,32 @@
+package manifold.ext.props.stuff;
+
+
+import manifold.ext.props.rt.api.PublicDefault;
+
+@PublicDefault
+public class PublicDefaultClass {
+    int defaultPublicVar;
+    private int defaultPrivateVar;
+    public int PublicVar;
+    protected int defaultProtectVar;
+
+    public PublicDefaultClass(int defaultPublicVar, int defaultPrivateVar, int publicVar, int defaultProtectVar){
+        this.defaultPublicVar = defaultPublicVar;
+        this.defaultPrivateVar = defaultPrivateVar;
+        this.PublicVar = publicVar;
+        this.defaultProtectVar = defaultProtectVar;
+    }
+
+    int defaultAddFunction(int a, int b){
+        return a+b;
+    }
+
+    class defaultClass{
+        int unreachableDefaultVar;
+        public int reachablePublicVar;
+    }
+
+    public class publicClass{
+        public int reachablePublicVar;
+    }
+}


### PR DESCRIPTION
I add an annotation "@PublicDefault" to change variable, method and class in a class to public by default.

For example, for a code:

```java
package manifold.ext.props.stuff;
public class PublicDefaultClass {
    int defaultPublicVar;
}
```

If a code is not in the same package with PublicDefaultClass, it can not access to defaultPublicVar. But by adding annotation like this:

```java
package manifold.ext.props.stuff;
@PublicDefault
public class PublicDefaultClass {
    int defaultPublicVar;
}
```

The variable defaultPublicVar can be accessed by changing the modifier of defaultPublicVar to public when compiling.

Now the feature supports variable, method and nested class.
