### PR TITLE
String template doesn't work with "provided" scope

### DIFF
--- a/manifold-deps-parent/manifold-strings/README.md
+++ b/manifold-deps-parent/manifold-strings/README.md
@@ -216,7 +216,6 @@ module MyProject {
             <groupId>systems.manifold</groupId>
             <artifactId>manifold-rt</artifactId>
             <version>${manifold.version}</version>
-            <scope>provided</scope> <!-- dependency is only applied during compile-time for manifold-strings -->
         </dependency>
     </dependencies>
   


### PR DESCRIPTION
This is a fix for issue #441 
This is probably not the right thing to do in the long term but can save users some time and pain until the right fix is made.