### PR TITLE
https://github.com/manifold-systems/manifold/issues/492

### DIFF
--- a/manifold-deps-parent/manifold-collections-test/src/test/java/manifold/collections/test/extensions/java/lang/Iterable/ManIterableExtTest.java
+++ b/manifold-deps-parent/manifold-collections-test/src/test/java/manifold/collections/test/extensions/java/lang/Iterable/ManIterableExtTest.java
@@ -152,9 +152,19 @@ public class ManIterableExtTest extends ExtensionManifoldTest {
     assertEquals(Arrays.asList("0s", "1k", "2c", "3l"), iter.mapIndexed( (i,e) -> ""+i+ e.charAt( 0 ) ));
   }
 
+  public void testMapIndexedToList()  {
+    Iterable<String> iter = makeTestIterable();
+    assertEquals(Arrays.asList("0s", "1k", "2c", "3l"), iter.mapIndexedToList( (i,e) -> ""+i+ e.charAt( 0 ) ));
+  }
+
   public void testMapIndexedNotNull()  {
     Iterable<String> iter = makeTestIterable();
     assertEquals(Arrays.asList("0s", "1k", "2c", "3l"), iter.mapIndexed( (i,e) -> ""+i+ e.charAt( 0 ) ));
+  }
+
+  public void testMapIndexedNotNullToList()  {
+    Iterable<String> iter = makeTestIterable();
+    assertEquals(Arrays.asList("0s", "1k", "2c", "3l"), iter.mapIndexedToList( (i,e) -> ""+i+ e.charAt( 0 ) ));
   }
 
   public void testMapIndexedNotNullTo()  {
@@ -170,6 +180,11 @@ public class ManIterableExtTest extends ExtensionManifoldTest {
   public void testMapNotNull()  {
     Iterable<String> iter = makeTestIterableWithNulls();
     assertEquals(Arrays.asList('s', 'k', 'c', 'l'), iter.mapNotNull( e -> e == null ? null : e.charAt(0) ));
+  }
+
+  public void testMapNotNullToList()  {
+    Iterable<String> iter = makeTestIterableWithNulls();
+    assertEquals(Arrays.asList('s', 'k', 'c', 'l'), iter.mapNotNullToList( e -> e == null ? null : e.charAt(0) ));
   }
 
   public void testMapNotNullTo()  {

--- a/manifold-deps-parent/manifold-collections/src/main/java/manifold/collections/extensions/java/lang/Iterable/ManIterableExt.java
+++ b/manifold-deps-parent/manifold-collections/src/main/java/manifold/collections/extensions/java/lang/Iterable/ManIterableExt.java
@@ -704,8 +704,22 @@ public class ManIterableExt
    *
    * @param transform function that takes the index of an element and the element itself
    *                  and returns the result of the transform applied to the element.
+   * @deprecated Use {@link #mapIndexedToList(Iterable, IndexedFunction)} instead.
    */
+  @Deprecated
   public static <T, R> List<R> mapIndexed( @This Iterable<T> thiz, IndexedFunction<T, R> transform )
+  {
+    return thiz.mapIndexedTo( new ArrayList<R>( collectionSizeOrDefault( thiz, 10 ) ), transform );
+  }
+
+  /**
+   * Returns a list containing the results of applying the given {@code transform} function
+   * to each element and its index in the original collection.
+   *
+   * @param transform function that takes the index of an element and the element itself
+   *                  and returns the result of the transform applied to the element.
+   */
+  public static <T, R> List<R> mapIndexedToList( @This Iterable<T> thiz, IndexedFunction<T, R> transform )
   {
     return thiz.mapIndexedTo( new ArrayList<R>( collectionSizeOrDefault( thiz, 10 ) ), transform );
   }
@@ -716,8 +730,22 @@ public class ManIterableExt
    *
    * @param transform function that takes the index of an element and the element itself
    *                  and returns the result of the transform applied to the element.
+   * @deprecated Use {@link #mapIndexedNotNullToList(Iterable, IndexedFunction)} instead.
    */
+  @Deprecated
   public static <T, R> List<R> mapIndexedNotNull( @This Iterable<T> thiz, IndexedFunction<T, R> transform )
+  {
+    return thiz.mapIndexedNotNullTo( new ArrayList<R>(), transform );
+  }
+
+  /**
+   * Returns a list containing only the non-null results of applying the given {@code transform} function
+   * to each element and its index in the original collection.
+   *
+   * @param transform function that takes the index of an element and the element itself
+   *                  and returns the result of the transform applied to the element.
+   */
+  public static <T, R> List<R> mapIndexedNotNullToList( @This Iterable<T> thiz, IndexedFunction<T, R> transform )
   {
     return thiz.mapIndexedNotNullTo( new ArrayList<R>(), transform );
   }
@@ -762,8 +790,19 @@ public class ManIterableExt
   /**
    * Returns a list containing only the non-null results of applying the given {@code transform} function
    * to each element in the original collection.
+   * @deprecated Use {@link #mapNotNullToList(Iterable, Function)} instead.
    */
+  @Deprecated
   public static <T, R> List<R> mapNotNull( @This Iterable<T> thiz, Function<T, R> transform )
+  {
+    return thiz.mapNotNullTo( new ArrayList<>(), transform );
+  }
+
+  /**
+   * Returns a list containing only the non-null results of applying the given {@code transform} function
+   * to each element in the original collection.
+   */
+  public static <T, R> List<R> mapNotNullToList( @This Iterable<T> thiz, Function<T, R> transform )
   {
     return thiz.mapNotNullTo( new ArrayList<>(), transform );
   }


### PR DESCRIPTION
 - add mapNotNullToList, mapIndexedToList and mapIndexedNotNullToList extension methods to ManIterableExt
 - deprecate mapNotNull, mapIndexed and mapIndexedNotNull extension methods in ManIterableExt

Closes #492 