### PR TITLE
JavacPlugin.java - Add "no-bootstrap" Package Specifiers

### DIFF
--- a/manifold-core-parent/manifold/README.md
+++ b/manifold-core-parent/manifold/README.md
@@ -341,7 +341,26 @@ options.compilerArgs += ['-Xplugin:Manifold no-bootstrap']
 </compilerArgs>
 ```
 If you need finer grained control over which classes have the static block, you can use the `@NoBootstrap` annotation
-to filter specific classes.
+to filter specific classes or specify package prefixes to exclude in the `no-bootstrap plugin` argument:
+
+```java
+import manifold.rt.api.NoBootstrap;
+
+@NoBootstrap
+public class MyClass {
+}
+```
+
+**Gradle**
+```groovy
+options.compilerArgs += ['-Xplugin:Manifold no-bootstrap my.package my.other.package']
+```  
+**Maven**
+```xml
+<compilerArgs>
+    <arg>-Xplugin:Manifold no-bootstrap my.package my.other.package</arg>
+</compilerArgs>
+```
 
 >Note, compile-only dependencies such as `manifold-preprocessor`, `manifold-exceptions`, and `manifold-strings` don't
 >involve any runtime dependencies, thus if your project's exposure to manifold is limited to these dependencies, the


### PR DESCRIPTION
Adds parsing for Javac arguments of the form `-Xplugin:Manifold no-bootstrap my.package.prefix my.package.prefix2`, specifying packages that are blacklisted from having the `<clinit>` bootstrap block injected into any of their child classes.

I also set it up so said package names will not trigger an invalid argument warning.

Fixes #634.

(While this would probably be better as a proper `-Aproperty=value` property, I stuck to how the javac plugin was already implemented to avoid breaking anything.)