### PR TITLE
Bugfix

### DIFF
--- a/manifold-util/src/main/java/manifold/util/ReflectUtil.java
+++ b/manifold-util/src/main/java/manifold/util/ReflectUtil.java
@@ -726,7 +726,7 @@ public class ReflectUtil
       List<Field> fields = fields( cls );
       return fields.stream()
         .map( f -> field( receiver, f.getName() ) )
-        .filter( lf -> filter != null && filter.test( lf ) )
+        .filter( lf -> filter == null || filter.test( lf ) )
         .collect( Collectors.toList() );
     }
     catch( Exception e )


### PR DESCRIPTION
This PR fixes a bug where the filter condition is always false when no filter predicate is provided (i.e. it is null).
A null filter is used on line 714: https://github.com/manifold-systems/manifold/blob/master/manifold-util/src/main/java/manifold/util/ReflectUtil.java#L714