### PR TITLE
Finding duplicate methods doesn't work when using 'smart' static methods

### DIFF
--- a/manifold-deps-parent/manifold-ext/src/main/java/manifold/ext/ExtCodeGen.java
+++ b/manifold-deps-parent/manifold-ext/src/main/java/manifold/ext/ExtCodeGen.java
@@ -606,10 +606,10 @@ class ExtCodeGen
       {
         List parameters = method.getParameters();
         List params = m.getParameters();
-        for( int i = 1; i < parameters.size(); i++ )
+        for( int i = paramsToSubtract; i < parameters.size(); i++ )
         {
           SrcParameter param = (SrcParameter)parameters.get( i );
-          SrcParameter p = (SrcParameter)params.get( i-1 );
+          SrcParameter p = (SrcParameter)params.get( i-paramsToSubtract );
           if( !param.getType().equals( p.getType() ) )
           {
             continue outer;

--- a/manifold-deps-parent/manifold-ext/src/main/java/manifold/ext/ExtCodeGen.java
+++ b/manifold-deps-parent/manifold-ext/src/main/java/manifold/ext/ExtCodeGen.java
@@ -584,7 +584,7 @@ class ExtCodeGen
     return true;
   }
 
-  private AbstractSrcMethod findMethod( AbstractSrcMethod method, SrcClass extendedType )
+  private AbstractSrcMethod findMethod( AbstractSrcMethod<?> method, SrcClass extendedType )
   {
     if( extendedType == null )
     {
@@ -592,10 +592,17 @@ class ExtCodeGen
     }
 
     AbstractSrcMethod duplicate = null;
+    int paramsToSubtract = 0;
+    if( !method.getParameters().isEmpty() )
+    {
+      SrcParameter firstParam = method.getParameters().get(0);
+      paramsToSubtract =
+          (firstParam.getAnnotation( This.class ) != null || firstParam.getAnnotation( ThisClass.class ) != null) ? 1 : 0;
+    }
     outer:
     for( AbstractSrcMethod m: extendedType.getMethods() )
     {
-      if( m.getSimpleName().equals( method.getSimpleName() ) && m.getParameters().size() == method.getParameters().size()-1 )
+      if( m.getSimpleName().equals( method.getSimpleName() ) && m.getParameters().size() == method.getParameters().size()-paramsToSubtract )
       {
         List parameters = method.getParameters();
         List params = m.getParameters();

--- a/manifold-deps-parent/manifold-ext/src/main/java/manifold/ext/ExtCodeGen.java
+++ b/manifold-deps-parent/manifold-ext/src/main/java/manifold/ext/ExtCodeGen.java
@@ -596,8 +596,7 @@ class ExtCodeGen
     if( !method.getParameters().isEmpty() )
     {
       SrcParameter firstParam = method.getParameters().get(0);
-      paramsToSubtract =
-          (firstParam.getAnnotation( This.class ) != null || firstParam.getAnnotation( ThisClass.class ) != null) ? 1 : 0;
+      paramsToSubtract = firstParam.hasAnnotation( This.class ) || firstParam.hasAnnotation( ThisClass.class ) ? 1 : 0;
     }
     outer:
     for( AbstractSrcMethod m: extendedType.getMethods() )


### PR DESCRIPTION
This PR fixes the following issue: https://github.com/manifold-systems/manifold/issues/657