### PR TITLE
Support auto return type in method reference

### DIFF
--- a/manifold-core-parent/manifold/src/main/java/manifold/api/util/IssueMsg.java
+++ b/manifold-core-parent/manifold/src/main/java/manifold/api/util/IssueMsg.java
@@ -30,7 +30,6 @@ public class IssueMsg
   public static final IssueMsg MSG_AUTO_RETURN_MORE_SPECIFIC_TYPE = new IssueMsg( "Cannot return 'auto', return a more specific type" );
   public static final IssueMsg MSG_AUTO_UNABLE_TO_RESOLVE_TYPE = new IssueMsg( "Unable to infer 'auto' type here" );
   public static final IssueMsg MSG_AUTO_CANNOT_INFER_FROM_NULL = new IssueMsg( "'auto' cannot infer from just 'null', cast 'null' or replace 'auto' with a type" );
-  public static final IssueMsg MSG_ANON_RETURN_METHOD_REF_NOT_SUPPORTED = new IssueMsg( "Method reference '{0}' must be invoked as a lambda expression here" );
 
   public static final IssueMsg MSG_OPT_PARAMS_POSITIONAL_BEFORE_NAMED = new IssueMsg( "Positional arguments must appear before named arguments" );
   public static final IssueMsg MSG_OPT_PARAMS_MISSING_REQ_ARG = new IssueMsg( "missing required argument: '{0}'" );

--- a/manifold-core-parent/manifold/src/main/java/manifold/internal/javac/ManAttr.java
+++ b/manifold-core-parent/manifold/src/main/java/manifold/internal/javac/ManAttr.java
@@ -1186,17 +1186,6 @@ public interface ManAttr
     return false;
   }
 
-  default void checkReference( JCTree.JCMemberReference tree )
-  {
-    boolean isAutoReturnType =
-      tree.sym instanceof Symbol.MethodSymbol && isAutoType( ((Symbol.MethodSymbol)tree.sym).getReturnType() );
-    if( isAutoReturnType )
-    {
-      // Method references not supported with tuple/anonymous return type
-      getLogger().error( tree.pos, "proc.messager", IssueMsg.MSG_ANON_RETURN_METHOD_REF_NOT_SUPPORTED.get( tree.sym.flatName() ) );
-    }
-  }
-
   static boolean isSynthetic( Symbol.MethodSymbol m )
   {
     return (m.flags() & Flags.SYNTHETIC) != 0 ||

--- a/manifold-core-parent/manifold/src/main/java/manifold/internal/javac/ManAttr_11.java11
+++ b/manifold-core-parent/manifold/src/main/java/manifold/internal/javac/ManAttr_11.java11
@@ -521,8 +521,6 @@ public class ManAttr_11 extends Attr implements ManAttr
   public void visitReference( JCTree.JCMemberReference tree )
   {
     super.visitReference( tree );
-
-    checkReference( tree );
   }
 
   @Override

--- a/manifold-core-parent/manifold/src/main/java/manifold/internal/javac/ManAttr_17.java17
+++ b/manifold-core-parent/manifold/src/main/java/manifold/internal/javac/ManAttr_17.java17
@@ -541,8 +541,6 @@ public class ManAttr_17 extends Attr implements ManAttr
   public void visitReference( JCTree.JCMemberReference tree )
   {
     super.visitReference( tree );
-
-    checkReference( tree );
   }
 
   @Override

--- a/manifold-core-parent/manifold/src/main/java/manifold/internal/javac/ManAttr_8.java
+++ b/manifold-core-parent/manifold/src/main/java/manifold/internal/javac/ManAttr_8.java
@@ -494,8 +494,6 @@ public class ManAttr_8 extends Attr implements ManAttr
   public void visitReference( JCTree.JCMemberReference tree )
   {
     super.visitReference( tree );
-
-    checkReference( tree );
   }
   
   @Override

--- a/manifold-deps-parent/manifold-ext-test/src/test/java/manifold/ext/SimpleTest.java
+++ b/manifold-deps-parent/manifold-ext-test/src/test/java/manifold/ext/SimpleTest.java
@@ -5,6 +5,7 @@ import manifold.api.type.BasicIncrementalCompileDriver;
 import manifold.api.type.ClassType;
 import manifold.api.type.ContributorKind;
 import manifold.ext.rt.api.Structural;
+import manifold.ext.rt.api.auto;
 
 import javax.swing.*;
 import java.awt.Rectangle;
@@ -144,6 +145,27 @@ public class SimpleTest extends SimpleTestSuper
     // no error should be thrown during compilation
     Consumer<ItemEvent> itemListener = null;
     new JComboBox<>().addItemListener(itemListener::accept);
+  }
+
+  public void testAutoReturnTypeInMethodRef()
+  {
+    // non-primitive return type
+    assertEquals( Collections.singletonList( "testauto" ),
+      Stream.of( "test" ).map( SimpleTest::returnAuto ).collect( Collectors.toList() ) );
+
+    // primitive return type
+    assertEquals( Collections.singletonList( 1 ),
+      Stream.of( "test" ).map( SimpleTest::returnAutoPrimitive ).collect( Collectors.toList() ) );
+  }
+
+  public static auto returnAuto(String text)
+  {
+    return text + "auto";
+  }
+
+  public static auto returnAutoPrimitive(String text)
+  {
+    return 1;
   }
 
   public static String appendBarStatic(String text){


### PR DESCRIPTION
Support auto return type in method reference

TODO: Compile `.java11` and `.java17` files with java 11 and 17 respectively. I'm currently having trouble getting this to work.