### PR TITLE
Fix intercept extension when first parameter has multiple annotations

### DIFF
--- a/manifold-deps-parent/manifold-ext-middle-test/src/main/java/abc/InterceptObject.java
+++ b/manifold-deps-parent/manifold-ext-middle-test/src/main/java/abc/InterceptObject.java
@@ -24,4 +24,9 @@ public class InterceptObject
     }
     return stringBuilder.toString();
   }
+
+  public String foo( )
+  {
+    return "foo";
+  }
 }

--- a/manifold-deps-parent/manifold-ext-test/pom.xml
+++ b/manifold-deps-parent/manifold-ext-test/pom.xml
@@ -41,6 +41,12 @@
         <artifactId>junit</artifactId>
         <scope>compile</scope>
       </dependency>
+      <dependency>
+        <groupId>org.jspecify</groupId>
+        <artifactId>jspecify</artifactId>
+        <version>1.0.0</version>
+        <scope>compile</scope>
+      </dependency>
     </dependencies>
 
     <build>

--- a/manifold-deps-parent/manifold-ext-test/src/main/java/manifold/extensions/abc/InterceptObject/InterceptObjectExt.java
+++ b/manifold-deps-parent/manifold-ext-test/src/main/java/manifold/extensions/abc/InterceptObject/InterceptObjectExt.java
@@ -4,6 +4,7 @@ import abc.InterceptObject;
 import manifold.ext.rt.api.Extension;
 import manifold.ext.rt.api.Intercept;
 import manifold.ext.rt.api.This;
+import org.jspecify.annotations.Nullable;
 
 @Extension
 public class InterceptObjectExt
@@ -32,5 +33,11 @@ public class InterceptObjectExt
   public static String repeatSelf( @This InterceptObject interceptObject, int times )
   {
     return times < 0 ? "negative amount" : interceptObject.repeatSelf( times );
+  }
+
+  @Intercept
+  public static String foo( @Nullable @This InterceptObject interceptObject )
+  {
+    return interceptObject == null ? null : interceptObject.foo();
   }
 }

--- a/manifold-deps-parent/manifold-ext-test/src/test/java/manifold/ext/InterceptTest.java
+++ b/manifold-deps-parent/manifold-ext-test/src/test/java/manifold/ext/InterceptTest.java
@@ -42,6 +42,12 @@ public class InterceptTest extends TestCase
         assertEquals( "negative amount", interceptObjectSub.repeatSelf( -2 ) );
     }
 
+    public void testInterceptMethodThisNotFirstAnnotation(){
+        InterceptTest.InterceptObjectSub interceptObjectSub = null;
+        assertEquals( null, interceptObjectSub.foo() );
+        assertEquals( "foo",  new InterceptTest.InterceptObjectSub( "" ).foo() );
+    }
+
     public static class InterceptObjectSub extends InterceptObject {
         public InterceptObjectSub(String text) {
             super(text);


### PR DESCRIPTION
Bugfix for handling cases where the first annotation of the first parameter of an intercepted method wasn't `@This` or `@ThisClass`, but another annotation such as `@Nullable`

e.g. (copied from test class)
```java
  @Intercept
  public static String foo( @Nullable @This InterceptObject interceptObject )
  {
    ...
  }
```