### PR TITLE
Improve temporary directory creation to eliminate race condition

### DIFF
--- a/manifold-deps-parent/manifold-io/src/main/java/manifold/io/extensions/java/io/File/ManFileExt.java
+++ b/manifold-deps-parent/manifold-io/src/main/java/manifold/io/extensions/java/io/File/ManFileExt.java
@@ -18,6 +18,7 @@ package manifold.io.extensions.java.io.File;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.FileAlreadyExistsException;
@@ -78,7 +79,7 @@ public class ManFileExt
   @Extension
   public static File createTempDir() throws IOException
   {
-    return createTempDir( "tmp", null, null );
+    return Files.createTempDirectory("tmp").toFile();
   }
 
   /**


### PR DESCRIPTION
### Description
This PR addresses a potential race condition/hijacking vulnerability in the temporary directory creation method. By replacing the current approach with Java NIO.2's Files.createTempDirectory() method, we eliminate the window of opportunity where another process could create something at the same path between file deletion and directory creation.

Something similar can be found here https://github.com/openkm/document-management-system/commit/c069e4d73ab8864345c25119d8459495f45453e1

### References
https://github.com/openkm/document-management-system/pull/332
https://github.com/openkm/document-management-system/commit/c069e4d73ab8864345c25119d8459495f45453e1