### PR TITLE
Infinite loop when intercepting a method invocation in a variable declaration

### DIFF
--- a/manifold-deps-parent/manifold-ext-test/src/test/java/manifold/ext/InterceptTest.java
+++ b/manifold-deps-parent/manifold-ext-test/src/test/java/manifold/ext/InterceptTest.java
@@ -48,6 +48,14 @@ public class InterceptTest extends TestCase
         assertEquals( "foo",  new InterceptTest.InterceptObjectSub( "" ).foo() );
     }
 
+    public void testInterceptInVariableDeclaration(){
+        assertEquals( "Hello test",  new InterceptVariableDecl().foo );
+    }
+
+    public static class InterceptVariableDecl {
+        private final String foo = ((InterceptObject) null).sayHello( "test" );
+    }
+
     public static class InterceptObjectSub extends InterceptObject {
         public InterceptObjectSub(String text) {
             super(text);

--- a/manifold-deps-parent/manifold-ext/src/main/java/manifold/ext/ExtensionTransformer.java
+++ b/manifold-deps-parent/manifold-ext/src/main/java/manifold/ext/ExtensionTransformer.java
@@ -3307,6 +3307,10 @@ public class ExtensionTransformer extends TreeTranslator
     // Traverse up the tree to find the method declaration
     while( !( parent instanceof JCTree.JCMethodDecl ) )
     {
+      if( parent == null )
+      {
+        return InterceptType.NORMAL;
+      }
       parent = _tp.getParent( parent );
     }
     JCTree.JCMethodDecl methodDecl = (JCTree.JCMethodDecl) parent;


### PR DESCRIPTION
See https://github.com/manifold-systems/manifold/issues/686

Consider the following example:

```java
public class MyClass {
    private String foo = null;
    private int bar = foo.length();
}


@Extension
public class StringExt {
    @Intercept
    public static int length(@This String string) {
        return string == null ? 0 : string.length();
    }
}
```

The issue is located in the method `getInterceptType`in class `ExtensionTranformer`. As there is no method declaration as parent, the parent will be `null` at some point. Calling `_tp.getParent( parent )` for a `null` parent also returns `null`, resulting in an infinite loop:

```java
Tree parent = _tp.getParent( tree );
// Traverse up the tree to find the method declaration
while( !( parent instanceof JCTree.JCMethodDecl ) )
{
  parent = _tp.getParent( parent );
}
```