### PR TITLE
Preprocessor - Add support of cpp tokens with #ifdef, #ifndef and defined

### DIFF
--- a/manifold-deps-parent/manifold-preprocessor-test/src/test/java/manifold/preprocessor/SimplePreprocessorTest.java
+++ b/manifold-deps-parent/manifold-preprocessor-test/src/test/java/manifold/preprocessor/SimplePreprocessorTest.java
@@ -174,4 +174,47 @@ public class SimplePreprocessorTest
     #endif
     return sb.toString();
   }
+  
+  @Test
+  public void testIfdef()
+  {
+    #ifdef AAA
+    String answer = "AAA";
+    #endif
+    
+    #ifdef BBB
+    String answer = "BBB";
+    #endif
+
+    assertEquals( "BBB", answer );
+  }
+  
+  @Test
+  public void testIfndef()
+  {
+    #ifndef AAA
+    String answer = "AAA";
+    #endif
+    
+    #ifndef BBB
+    String answer = "BBB";
+    #endif
+
+    assertEquals( "AAA", answer );
+  }
+  
+  @Test
+  public void testDefined()
+  {
+    #if defined(AAA)
+    String answer = "AAA";
+    #endif
+    
+    #if defined(BBB)
+    String answer = "BBB";
+    #endif
+
+    assertEquals( "BBB", answer );
+  }
+  
 }

--- a/manifold-deps-parent/manifold-preprocessor/src/main/java/manifold/preprocessor/TokenType.java
+++ b/manifold-deps-parent/manifold-preprocessor/src/main/java/manifold/preprocessor/TokenType.java
@@ -25,6 +25,8 @@ public enum TokenType
   CharLiteral(),
   TextBlock(),
   If("if"),
+  Ifdef("ifdef"),
+  Ifndef("ifndef"),
   Elif("elif"),
   Else("else"),
   Endif("endif"),

--- a/manifold-deps-parent/manifold-preprocessor/src/main/java/manifold/preprocessor/Tokenizer.java
+++ b/manifold-deps-parent/manifold-preprocessor/src/main/java/manifold/preprocessor/Tokenizer.java
@@ -161,6 +161,26 @@ public class Tokenizer
       _expr = new ExpressionParser( _buffer, offset, _bufferEndOffset ).parse();
       _tokenEndOffset = _expr.getEndOffset();
     }
+    else if( match( TokenType.Ifdef.getDirective(), offset ) )
+    {
+      offset += TokenType.Ifdef.getDirective().length();
+      _tokenType = TokenType.Ifdef;
+
+      offset = skipWhitespace( offset, false );
+      _expr = new ExpressionParser( _buffer, offset, _bufferEndOffset ).parse();
+
+      _tokenEndOffset = _expr.getEndOffset();
+    }
+    else if( match( TokenType.Ifndef.getDirective(), offset ) )
+    {
+      offset += TokenType.Ifndef.getDirective().length();
+      _tokenType = TokenType.Ifndef;
+
+      offset = skipWhitespace( offset, false );
+      _expr = new ExpressionParser( _buffer, offset, _bufferEndOffset ).parse();
+
+      _tokenEndOffset = _expr.getEndOffset();
+    }
     else if( match( TokenType.Elif.getDirective(), offset ) )
     {
       offset += TokenType.Elif.getDirective().length();

--- a/manifold-deps-parent/manifold-preprocessor/src/main/java/manifold/preprocessor/expression/ExpressionParser.java
+++ b/manifold-deps-parent/manifold-preprocessor/src/main/java/manifold/preprocessor/expression/ExpressionParser.java
@@ -136,15 +136,22 @@ public class ExpressionParser
     {
       skipWhitespace();
       if ( match( ExpressionTokenType.OpenParen )) {
-          int startOffset = expr.getStartOffset();
-          expr = parseUnaryExpression();
+        int startOffset = expr.getStartOffset();
+        expr = parseUnaryExpression();
 
-          skipWhitespace();
-          if ( !match( ExpressionTokenType.CloseParen )) {
-            expr.error( "')' Expected", _tokenizer.getTokenStart() );
-          }
-          int endOffset = _tokenizer.getTokenEnd();
+        skipWhitespace();
+        if ( !match( ExpressionTokenType.CloseParen )) {
+          expr.error( "Expecting ')'", _tokenizer.getTokenStart() );
+        }
+        int endOffset = _tokenizer.getTokenEnd();
+        if( expr instanceof Identifier )
+        {
           expr = new Identifier(((Identifier)expr).getName(), startOffset, endOffset );
+        }
+        else
+        {
+          expr.error( "Expecting an identifier within defined(...) expression", expr.getStartOffset() );
+        }
       }
 
     }
@@ -166,7 +173,7 @@ public class ExpressionParser
       int endOffset = expr.getEndOffset();
       if( !match( ExpressionTokenType.CloseParen, false ) )
       {
-        expr.error( "')' Expected", _tokenizer.getTokenStart() );
+        expr.error( "Expecting ')'", _tokenizer.getTokenStart() );
       }
       else
       {

--- a/manifold-deps-parent/manifold-preprocessor/src/main/java/manifold/preprocessor/expression/ExpressionParser.java
+++ b/manifold-deps-parent/manifold-preprocessor/src/main/java/manifold/preprocessor/expression/ExpressionParser.java
@@ -108,7 +108,7 @@ public class ExpressionParser
   {
     int offset = skipWhitespace();
 
-    Expression lhs = parseUnaryExpression();
+    Expression lhs = parseUnaryDefinedExpression();
     while( true )
     {
       skipWhitespace();
@@ -118,7 +118,7 @@ public class ExpressionParser
           match( ExpressionTokenType.lt ) ||
           match( ExpressionTokenType.le ) )
       {
-        Expression rhs = parseUnaryExpression();
+        Expression rhs = parseUnaryDefinedExpression();
         lhs = new RelationalExpression( lhs, rhs, tokenType.getToken(), offset, rhs.getEndOffset() );
       }
       else
@@ -129,13 +129,35 @@ public class ExpressionParser
     return lhs;
   }
 
+  private Expression parseUnaryDefinedExpression()
+  {
+    Expression expr = parseUnaryExpression();
+    if ( (expr instanceof Identifier) && ((Identifier)expr).getName().equals("defined") )
+    {
+      skipWhitespace();
+      if ( match( ExpressionTokenType.OpenParen )) {
+          int startOffset = expr.getStartOffset();
+          expr = parseUnaryExpression();
+
+          skipWhitespace();
+          if ( !match( ExpressionTokenType.CloseParen )) {
+            expr.error( "')' Expected", _tokenizer.getTokenStart() );
+          }
+          int endOffset = _tokenizer.getTokenEnd();
+          expr = new Identifier(((Identifier)expr).getName(), startOffset, endOffset );
+      }
+
+    }
+    return expr;
+  }
+
   private Expression parseUnaryExpression()
   {
     int offset = skipWhitespace();
 
     if( match( ExpressionTokenType.Not ) )
     {
-      Expression expr = parseUnaryExpression();
+      Expression expr = parseUnaryDefinedExpression();
       return new NotExpression( expr, offset, expr.getEndOffset() );
     }
     else if( match( ExpressionTokenType.OpenParen ) )

--- a/manifold-deps-parent/manifold-preprocessor/src/main/java/manifold/preprocessor/expression/NotExpression.java
+++ b/manifold-deps-parent/manifold-preprocessor/src/main/java/manifold/preprocessor/expression/NotExpression.java
@@ -24,7 +24,7 @@ public class NotExpression extends Expression
 {
   private final Expression _expr;
 
-  NotExpression( Expression expr, int start, int end )
+  public NotExpression( Expression expr, int start, int end )
   {
     super( start, end );
     _expr = expr;


### PR DESCRIPTION
Support preprocessing directives which are compliant with cpp preprocessor.
Examples:

#ifdef _DIRECTIVE_
#endif

#ifndef _DIRECTIVE_
#endif

#if defined(_DIRECTIVE1_) || defined(_DIRECTIVE2_)
#endif
